### PR TITLE
Fix stereo position-output parsing for vs_3_0 shaders (Batman: Arkham Asylum GOTY)

### DIFF
--- a/S3DWrapper9/ShaderInstruction.cpp
+++ b/S3DWrapper9/ShaderInstruction.cpp
@@ -79,7 +79,33 @@ inline bool GetShaderoPosName(DWORD shaderVersion, const char* inputShader, char
 	{
 		const char* dcl_pos = strrstr(inputShader, "dcl_position");
 		if (dcl_pos)
-			sscanf(dcl_pos, "dcl_position %s", oPosName);
+		{
+			dcl_pos += (int)strlen("dcl_position");
+
+			while (*dcl_pos && *dcl_pos >= '0' && *dcl_pos <= '9')	// skip usage index (e.g. "dcl_position0")
+				dcl_pos++;
+
+			while (*dcl_pos && (*dcl_pos == ' ' || *dcl_pos == '\t' || *dcl_pos == '\n'))
+				dcl_pos++;
+
+			int len = 0;
+			while (dcl_pos[len] &&
+			       dcl_pos[len] != ' ' &&
+			       dcl_pos[len] != '\t' &&
+			       dcl_pos[len] != '\n')
+				len++;
+
+			if (len > 0)
+			{
+				memcpy(oPosName, dcl_pos, len);
+				oPosName[len] = '\0';
+			}
+			else
+			{
+				oPosName[0] = '\0';
+				return false;
+			}
+		}
 		else
 		{
 			oPosName[0] = '\0';


### PR DESCRIPTION
I'm on Linux running the game through Proton/Wine. SBS works fine, the game comes up, but it never actually rendered stereo. It just displayed the same "eye" image side by side. Turns out the problem was a small parsing bug in GetShaderoPosName in S3DWrapper9/ShaderInstruction.cpp.

For vs_3_0 shaders (what Batman compiles) the register name was read with:

sscanf(dcl_pos, "dcl_position %s", oPosName);

but D3DX actually disassembles to dcl_position0 o1 — that usage index "0" comes right after the keyword, no space. So sscanf never matched, oPosName was left as uninitialized garbage, the analyzer couldn't match any destination register as the position output, and every shader got flagged mono. Stereo pipeline never ran.

The fix just skips the usage digits and whitespace after dcl_position and copies the real register token (o1, o0, ...) instead of relying on sscanf. Now the analyzer can see writes to the position output and the shader gets converted for stereo. I've confirmed it renders in 3D on my Proton/Wine setup.

I don't really know shaders well, so I can't be sure there are no side effects.

I also tested with the Witcher 2: Assassins of Kings, another directx 9 game with 32 bit. It worked before my patch, and it continued to work after my patch. 