### PR TITLE
Crysis 1 (DirectX 9 x86) - madCHook shim: hand back a trampoline when MinHook reports ALREADY_CREATED

### DIFF
--- a/lib/madCHook/madCHook.h
+++ b/lib/madCHook/madCHook.h
@@ -57,6 +57,17 @@ namespace madCHookShim {
         return entries;
     }
 
+    // MinHook fills the caller's "original" only on MH_OK, so remember trampolines ourselves.
+    struct TrampolineEntry {
+        LPVOID pTarget;
+        LPVOID pTrampoline;
+    };
+
+    inline std::vector<TrampolineEntry>& GetTrampolines() {
+        static std::vector<TrampolineEntry> tramps;
+        return tramps;
+    }
+
     inline std::mutex& GetMutex() {
         static std::mutex mtx;
         return mtx;
@@ -65,6 +76,26 @@ namespace madCHookShim {
     inline void RegisterHook(LPVOID pTarget, PVOID* ppOriginal) {
         std::lock_guard<std::mutex> lock(GetMutex());
         GetHookEntries().push_back({ pTarget, ppOriginal });
+    }
+
+    inline void RememberTrampoline(LPVOID pTarget, LPVOID pTrampoline) {
+        std::lock_guard<std::mutex> lock(GetMutex());
+        for (auto& e : GetTrampolines()) {
+            if (e.pTarget == pTarget) {
+                e.pTrampoline = pTrampoline;
+                return;
+            }
+        }
+        GetTrampolines().push_back({ pTarget, pTrampoline });
+    }
+
+    inline LPVOID FindTrampoline(LPVOID pTarget) {
+        std::lock_guard<std::mutex> lock(GetMutex());
+        for (auto& e : GetTrampolines()) {
+            if (e.pTarget == pTarget)
+                return e.pTrampoline;
+        }
+        return nullptr;
     }
 
     inline LPVOID FindTarget(PVOID* ppOriginal) {
@@ -164,8 +195,17 @@ inline BOOL HookAPI(const char* pszModule, const char* pszFuncName,
     // Use MH_CreateHook with the resolved address (more reliable than MH_CreateHookApi
     // when the module was loaded via full path)
     MH_STATUS status = MH_CreateHook((LPVOID)pTarget, pDetour, ppOriginal);
-    if (status != MH_OK && status != MH_ERROR_ALREADY_CREATED)
+    if (status == MH_OK) {
+        madCHookShim::RememberTrampoline((LPVOID)pTarget, *ppOriginal);
+    } else if (status == MH_ERROR_ALREADY_CREATED) {
+        // See HookCode: MinHook does not fill *ppOriginal in this case.
+        LPVOID pTrampoline = madCHookShim::FindTrampoline((LPVOID)pTarget);
+        if (!pTrampoline)
+            return FALSE;
+        *ppOriginal = pTrampoline;
+    } else {
         return FALSE;
+    }
 
     // Track it so UnhookAPI can find the target
     madCHookShim::RegisterHook((LPVOID)pTarget, ppOriginal);
@@ -216,8 +256,17 @@ inline BOOL HookCode(PVOID pCode, void* pCallback, PVOID* ppNextHook, DWORD /*fl
         return FALSE;
 
     MH_STATUS status = MH_CreateHook(pCode, pCallback, ppNextHook);
-    if (status != MH_OK && status != MH_ERROR_ALREADY_CREATED)
+    if (status == MH_OK) {
+        madCHookShim::RememberTrampoline(pCode, *ppNextHook);
+    } else if (status == MH_ERROR_ALREADY_CREATED) {
+        // Several proxies hook one shared d3d9 function, so reuse the first trampoline.
+        LPVOID pTrampoline = madCHookShim::FindTrampoline(pCode);
+        if (!pTrampoline)
+            return FALSE;
+        *ppNextHook = pTrampoline;
+    } else {
         return FALSE;
+    }
 
     madCHookShim::RegisterHook(pCode, ppNextHook);
 


### PR DESCRIPTION
MinHook writes the caller's "original" pointer only on MH_OK. A second MH_CreateHook against an already-hooked target returns MH_ERROR_ALREADY_CREATED and leaves that pointer untouched — but the shim treated it as success, enabled the hook, and returned TRUE, so the detour went live while the caller kept a NULL original.

Every IDirect3DSurface9 shares one vtable, so the three proxies hooking slot 12 (WideSwapChain.cpp:122/:181, WideStereoRenderer.cpp:1000) all target the same d3d9 function; only the first got a trampoline. Crysis 1 crashed before its menu with all twelve Wide::Original_* globals reading 0x00000000. The shim now memoizes each target's trampoline and hands it to later callers.

Verified: Crysis 1 (EA, 32-bit, -dx9 via C1-Launcher v8) — from instant pre-menu crash to full stereo gameplay with SideBySideOutput (SR Weave Output crashes on load because C1 Launcher does something funky as load finishes with the fullscreen). Tested on Acer Predator Spatiallabs View 27".

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/eebd12a7-25f7-4977-b128-6e759c43c874" />
