### PR TITLE
NvApiProxy: add IgnoreStereoDisable so games keep their own stereo renderer

### DIFF
--- a/NvDirectMode/3DVision_Config.xml
+++ b/NvDirectMode/3DVision_Config.xml
@@ -163,6 +163,23 @@
              proxy). Default: 0. -->
         <DisableStereoSpoof Value="0"/>
 
+        <!-- IgnoreStereoDisable: 1 = Stereo_Deactivate is answered NVAPI_OK but
+             otherwise ignored, so Stereo_IsActivated keeps reporting true.
+
+             Games with their own stereo renderer switch NVIDIA's *automatic*
+             stereo off by design, then poll IsActivated to decide whether to
+             keep rendering their own. Honouring the Deactivate answers "no" and
+             they drop to mono — the game never calls Stereo_Activate or
+             SetActiveEye, so NvDirectMode has no per-eye output to route.
+
+             Confirmed on Crysis 3 (CryEngine): without this it stops at
+             CreateHandleFromIUnknown → Deactivate and renders mono; with it the
+             sequence completes to Activate → SetActiveEye and per-eye capture
+             runs. Equivalent to 3Dmigoto's NoStereoDisable.
+
+             Read by nvapi[64].dll on DLL_PROCESS_ATTACH. Default: 0. -->
+        <IgnoreStereoDisable Value="0"/>
+
         <!-- UseLayoutStableProxy: D3D9 ONLY (ignored on d3d10/d3d11/opengl32).
              Tiered for games whose anti-tamper sniffs IDirect3D9 / Device
              internals.

--- a/NvDirectMode/NvApiProxy/NvApiProxy.cpp
+++ b/NvDirectMode/NvApiProxy/NvApiProxy.cpp
@@ -252,6 +252,12 @@ static FakeStereoState g_Stereo = {
 // ============================================================
 static int g_disableStereoSpoof = 0;
 
+// Games with their own stereo renderer switch NVIDIA auto-stereo off, then ask
+// whether stereo is active to decide if they keep rendering it (Crysis 3).
+// Honouring the Deactivate answers "no" and they drop to mono. Same switch as
+// 3Dmigoto's NoStereoDisable (NVAPI/DllMain.cpp).
+static int g_ignoreStereoDisable = 0;
+
 // ============================================================
 // Stereo_SetNotificationMessage state. NVAPI lets a game register
 // (HWND, messageId); the driver PostMessage()s that message whenever
@@ -307,7 +313,8 @@ static void LoadConfig(HMODULE hSelf)
     buf[n] = '\0';
     fclose(f);
 
-    g_disableStereoSpoof = ReadConfigInt(buf, "DisableStereoSpoof", g_disableStereoSpoof);
+    g_disableStereoSpoof  = ReadConfigInt(buf, "DisableStereoSpoof", g_disableStereoSpoof);
+    g_ignoreStereoDisable = ReadConfigInt(buf, "IgnoreStereoDisable", g_ignoreStereoDisable);
     free(buf);
 }
 
@@ -698,6 +705,11 @@ NVAPI_INTERFACE Spoof_Stereo_Activate(StereoHandle)
 NVAPI_INTERFACE Spoof_Stereo_Deactivate(StereoHandle)
 {
     NVAPI_TRACE_FIRST("Stereo_Deactivate");
+    if (g_ignoreStereoDisable)
+    {
+        WriteLog("[NvApiProxy] Stereo_Deactivate ignored (IgnoreStereoDisable=1)\n");
+        return NVAPI_OK;
+    }
     if (ResolveWiz3DBridge() && ShouldApplyGameSet(g_gameHasReadActive))
         g_Wiz3D.SetStereoActive(0);
     g_Stereo.isActive = 0;
@@ -1296,8 +1308,8 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
         LoadConfig(hModule);
         char attachLine[160];
         _snprintf_s(attachLine, sizeof(attachLine), _TRUNCATE,
-                    "[NvApiProxy] DLL_PROCESS_ATTACH (wiz3D " DISPLAYED_VERSION ") DisableStereoSpoof=%d\n",
-                    g_disableStereoSpoof);
+                    "[NvApiProxy] DLL_PROCESS_ATTACH (wiz3D " DISPLAYED_VERSION ") DisableStereoSpoof=%d IgnoreStereoDisable=%d\n",
+                    g_disableStereoSpoof, g_ignoreStereoDisable);
         WriteLog(attachLine);
     }
     else if (reason == DLL_PROCESS_DETACH)


### PR DESCRIPTION
Games that render stereo themselves switch NVIDIA's automatic stereo off by design, then poll Stereo_IsActivated to decide whether to keep rendering it. Honouring the Deactivate answered "no", so they dropped to mono and never reached Stereo_Activate/SetActiveEye — leaving NvDirectMode with no per-eye output to route.

Verified: Crysis 3 (EA, 1.3.0.0) — previously stopped dead at CreateHandleFromIUnknown → Deactivate and rendered mono; with the flag it completes to Activate → SetActiveEye, per-eye capture runs every frame, and the SR weave passes its 1800-weave heartbeat for the first time.

Don't have a screenshot because the 3D depth is too low and I reverted later to use SBS. Tested on Acer Predator Spatiallabs View 27 with SR Weave output for both Crysis 2 and 3.