### PR TITLE
GTA V Legacy (DX11 x64) - proxy: write UMD filename to both Win32 and Win64 registry keys

### DIFF
--- a/wiz3D-proxy/dxgi/dllmain.cpp
+++ b/wiz3D-proxy/dxgi/dllmain.cpp
@@ -770,22 +770,32 @@ static void SetupUmdRegistry(void)
             const WCHAR* pFileName = wcsrchr(umdPath, L'\\');
             pFileName = pFileName ? pFileName + 1 : umdPath;
 
-            HKEY hIZ3DKey;
-            if (RegCreateKeyExW(HKEY_CURRENT_USER,
-                    L"SOFTWARE\\iZ3D\\iZ3D Driver\\Win32",
-                    0, NULL, 0, KEY_WRITE, NULL, &hIZ3DKey, NULL) == ERROR_SUCCESS)
+            // Consumers pick the key by architecture (S3DWrapper10, S3DUtils,
+            // S3DInjector all do #ifndef WIN64 -> Win32 else Win64). Write both
+            // so a 64-bit wrapper finds it; a missing value made OpenAdapter10
+            // return E_FAIL, so D3D11CreateDevice handed the game a null device.
+            static const WCHAR* const kKeys[] = {
+                L"SOFTWARE\\iZ3D\\iZ3D Driver\\Win32",
+                L"SOFTWARE\\iZ3D\\iZ3D Driver\\Win64",
+            };
+            DWORD cbData = (DWORD)((wcslen(pFileName) + 1) * sizeof(WCHAR));
+            for (int k = 0; k < 2; ++k)
             {
-                DWORD cbData = (DWORD)((wcslen(pFileName) + 1) * sizeof(WCHAR));
-                RegSetValueExW(hIZ3DKey, L"DriverD3D10VistaModule", 0, REG_SZ,
-                    (const BYTE*)pFileName, cbData);
-                RegSetValueExW(hIZ3DKey, L"DriverD3D10Win7Module", 0, REG_SZ,
-                    (const BYTE*)pFileName, cbData);
-                RegCloseKey(hIZ3DKey);
-                Log("  Wrote UMD filename '%ls' to iZ3D registry\n", pFileName);
-            }
-            else
-            {
-                Log("  WARN: Could not write UMD filename to iZ3D registry\n");
+                HKEY hIZ3DKey;
+                if (RegCreateKeyExW(HKEY_CURRENT_USER, kKeys[k],
+                        0, NULL, 0, KEY_WRITE, NULL, &hIZ3DKey, NULL) == ERROR_SUCCESS)
+                {
+                    RegSetValueExW(hIZ3DKey, L"DriverD3D10VistaModule", 0, REG_SZ,
+                        (const BYTE*)pFileName, cbData);
+                    RegSetValueExW(hIZ3DKey, L"DriverD3D10Win7Module", 0, REG_SZ,
+                        (const BYTE*)pFileName, cbData);
+                    RegCloseKey(hIZ3DKey);
+                    Log("  Wrote UMD filename '%ls' to %ls\n", pFileName, kKeys[k]);
+                }
+                else
+                {
+                    Log("  WARN: Could not write UMD filename to %ls\n", kKeys[k]);
+                }
             }
         }
 


### PR DESCRIPTION
Consumers select the key by architecture (S3DWrapper10, S3DUtils and S3DInjector all do #ifndef WIN64 -> Win32 else Win64), but the proxy hardcoded Win32. On x64 the wrapper read Win64, found nothing, so GetDriverModuleName returned an empty string and OpenAdapter10 failed its module load with E_FAIL. D3D11CreateDevice then returned DXGI_ERROR_UNSUPPORTED with a null device, which GTA V dereferenced.

Verified on GTA V x64: device creation now succeeds and the game reaches the menu. x86 titles were unaffected because both sides agreed on Win32.

Screenshots of working 3D in the follow up PR for DX11.